### PR TITLE
basic support for campaigns

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.tabSize": 2
 }

--- a/database/postgresDB.sql
+++ b/database/postgresDB.sql
@@ -133,3 +133,5 @@ CREATE TABLE vennt.campaign_entities (
     gm_only boolean NOT NULL DEFAULT false
 );
 
+-- Unique constraint on campaign_entities
+CREATE UNIQUE INDEX campaign_entity_unique ON vennt.campaign_entities(campaign_id uuid_ops,entity_id uuid_ops);

--- a/database/postgresDB.sql
+++ b/database/postgresDB.sql
@@ -79,7 +79,7 @@ CREATE TABLE vennt.entity_text (
 );
 CREATE UNIQUE INDEX entity_key_unique ON vennt.entity_text(entity_id uuid_ops,key text_ops);
 
--- entity_flux
+-- flux
 
 CREATE TABLE vennt.flux (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
@@ -95,11 +95,11 @@ CREATE TABLE vennt.flux (
 
 CREATE TABLE vennt.campaigns (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
-    name text NOT NULL,
-    owner uuid NOT NULL REFERENCES vennt.accounts(id),
+    name text NOT NULL UNIQUE,
     in_combat boolean NOT NULL DEFAULT false,
     init_index integer NOT NULL DEFAULT 0,
-    init_round integer NOT NULL DEFAULT 0
+    init_round integer NOT NULL DEFAULT 0,
+    "desc" text NOT NULL
 );
 
 -- campaign_invites
@@ -109,8 +109,10 @@ CREATE TABLE vennt.campaign_invites (
     campaign_id uuid NOT NULL REFERENCES vennt.campaigns(id) ON DELETE CASCADE,
     "from" uuid NOT NULL REFERENCES vennt.accounts(id) ON DELETE CASCADE,
     "to" uuid NOT NULL REFERENCES vennt.accounts(id) ON DELETE CASCADE,
+    role text NOT NULL DEFAULT 'SPECTATOR'::text,
     created timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
+CREATE UNIQUE INDEX campaign_to_unique ON vennt.campaign_invites(campaign_id uuid_ops,"to" uuid_ops);
 
 -- campaign_members
 
@@ -124,9 +126,10 @@ CREATE UNIQUE INDEX campaign_account_unique ON vennt.campaign_members(campaign_i
 
 -- campaign_entities
 
-CREATE TABLE vennt.campaign_entites (
+CREATE TABLE vennt.campaign_entities (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     campaign_id uuid NOT NULL REFERENCES vennt.campaigns(id) ON DELETE CASCADE,
     entity_id uuid NOT NULL REFERENCES vennt.entities(id) ON DELETE CASCADE,
     gm_only boolean NOT NULL DEFAULT false
 );
+

--- a/src/daos/campaignDao.ts
+++ b/src/daos/campaignDao.ts
@@ -1,5 +1,6 @@
 import {
   AccountInfo,
+  CampaignDesc,
   CampaignEntity,
   CampaignInvite,
   CampaignInviteWithDetails,
@@ -25,6 +26,7 @@ import {
   sqlInsertCampaignMember,
   sqlInsertCampaignMemberFromInvite,
   sqlListCampaignsForAccount,
+  sqlUpdateCampaignDesc,
 } from "./sql";
 import pool from "../utils/pool";
 import {
@@ -92,6 +94,13 @@ export const dbFetchFullCampaignDetails = async (
     members,
     entities,
   });
+};
+
+export const dbUpdateCampaignDesc = async (
+  campaignId: string,
+  desc: CampaignDesc
+): Promise<Result<boolean>> => {
+  return await sqlUpdateCampaignDesc(pool, campaignId, desc);
 };
 
 export const dbInsertCampaignEntity = async (

--- a/src/daos/campaignDao.ts
+++ b/src/daos/campaignDao.ts
@@ -1,0 +1,145 @@
+import {
+  AccountInfo,
+  CampaignEntity,
+  CampaignInvite,
+  CampaignInviteWithDetails,
+  CampaignRole,
+  CampaignWithRole,
+  FullCampaignDetails,
+  PostCampaign,
+  PostCampaignEntity,
+  PostCampaignInvite,
+  Result,
+} from "../utils/types";
+import {
+  sqlDeleteCampaignInvite,
+  sqlFetchCampaignById,
+  sqlFetchCampaignEntitiesByCampaignId,
+  sqlFetchCampaignInvitesByCampaignId,
+  sqlFetchCampaignInvitesByRecipientId,
+  sqlFetchCampaignMembersByCampaignId,
+  sqlFetchCampaignRole,
+  sqlInsertCampaign,
+  sqlInsertCampaignEntity,
+  sqlInsertCampaignInvite,
+  sqlInsertCampaignMember,
+  sqlInsertCampaignMemberFromInvite,
+  sqlListCampaignsForAccount,
+} from "./sql";
+import pool from "../utils/pool";
+import {
+  UNAUTHORIZED_RESULT,
+  handleTransaction,
+  unwrapResultOrError,
+  wrapSuccessResult,
+} from "../utils/db";
+
+export const dbInsertCampaign = async (
+  campaign: PostCampaign,
+  accountId: string
+): Promise<Result<FullCampaignDetails>> => {
+  return handleTransaction(async (tx) => {
+    const insertedCampaign = unwrapResultOrError(
+      await sqlInsertCampaign(tx, campaign)
+    );
+    const insertedMember = unwrapResultOrError(
+      await sqlInsertCampaignMember(tx, insertedCampaign.id, accountId, "GM")
+    );
+    return wrapSuccessResult({
+      campaign: insertedCampaign,
+      invites: [],
+      members: [insertedMember],
+      entities: [],
+    });
+  });
+};
+
+export const dbFetchCampaignRole = async (
+  campaignId: string,
+  accountId: string
+): Promise<Result<CampaignRole>> => {
+  return await sqlFetchCampaignRole(pool, campaignId, accountId);
+};
+
+export const dbListCampaigns = async (
+  accountId: string
+): Promise<Result<CampaignWithRole[]>> => {
+  return await sqlListCampaignsForAccount(pool, accountId);
+};
+
+export const dbFetchFullCampaignDetails = async (
+  campaignId: string,
+  role: CampaignRole
+): Promise<Result<FullCampaignDetails>> => {
+  const gmView = role === "GM";
+  const [campaign, invites, members, entities] = await Promise.all([
+    unwrapResultOrError(await sqlFetchCampaignById(pool, campaignId)),
+    gmView
+      ? unwrapResultOrError(
+          await sqlFetchCampaignInvitesByCampaignId(pool, campaignId)
+        )
+      : [],
+    unwrapResultOrError(
+      await sqlFetchCampaignMembersByCampaignId(pool, campaignId)
+    ),
+    unwrapResultOrError(
+      await sqlFetchCampaignEntitiesByCampaignId(pool, campaignId, gmView)
+    ),
+  ]);
+  return wrapSuccessResult({
+    campaign,
+    invites,
+    members,
+    entities,
+  });
+};
+
+export const dbInsertCampaignEntity = async (
+  campaignId: string,
+  campaignEntity: PostCampaignEntity,
+  role: CampaignRole
+): Promise<Result<CampaignEntity>> => {
+  if (role !== "GM" && campaignEntity.gm_only) {
+    return UNAUTHORIZED_RESULT;
+  }
+  return sqlInsertCampaignEntity(
+    pool,
+    campaignId,
+    campaignEntity.entity_id,
+    campaignEntity.gm_only
+  );
+};
+
+export const dbInsertCampaignInvite = async (
+  invite: PostCampaignInvite,
+  from: AccountInfo
+): Promise<Result<CampaignInvite>> => {
+  return sqlInsertCampaignInvite(pool, invite, from);
+};
+
+export const dbListCampaignInvites = async (
+  account: AccountInfo
+): Promise<Result<CampaignInviteWithDetails[]>> => {
+  return await sqlFetchCampaignInvitesByRecipientId(
+    pool,
+    account.id,
+    account.username
+  );
+};
+
+export const dbAcceptCampaignInvite = async (
+  inviteId: string,
+  accountId: string
+): Promise<Result<boolean>> => {
+  return handleTransaction(async (tx) => {
+    await sqlInsertCampaignMemberFromInvite(tx, inviteId, accountId);
+    return sqlDeleteCampaignInvite(tx, inviteId, accountId);
+  });
+};
+
+export const dbDeclineCampaignInvite = async (
+  inviteId: string,
+  accountId: string
+): Promise<Result<boolean>> => {
+  return sqlDeleteCampaignInvite(pool, inviteId, accountId);
+};

--- a/src/daos/entityDao.ts
+++ b/src/daos/entityDao.ts
@@ -94,6 +94,8 @@ export const dbFetchCollectedEntity = async (
   const entity = await sqlFetchEntityById(pool, id);
   if (!entity.success) return entity;
   if (!entity.result.public && entity.result.owner !== user) {
+    // TODO: should check if user is in same campaign as this entity - maybe by passing in optional campaignId query param
+    // also, we should probably Promise.all so we can run everything async
     return FORBIDDEN_RESULT;
   }
 
@@ -106,6 +108,7 @@ export const dbFetchCollectedEntity = async (
   const text = await sqlFetchEntityTextByEntityId(
     pool,
     id,
+    // If user is GM, also set this to true
     entity.result.owner !== user
   );
   if (!text.success) return text;

--- a/src/daos/sql.ts
+++ b/src/daos/sql.ts
@@ -9,6 +9,7 @@ import {
 import {
   AccountInfo,
   Campaign,
+  CampaignDesc,
   CampaignEntity,
   CampaignInvite,
   CampaignInviteWithDetails,
@@ -637,6 +638,18 @@ export const sqlFetchCampaignById = async (
   );
 };
 
+export const sqlUpdateCampaignDesc = async (
+  tx: TX,
+  campaignId: string,
+  { desc }: CampaignDesc
+): Promise<Result<boolean>> => {
+  await tx.query(`UPDATE ${CAMPAIGNS_TABLE} SET "desc" = $1 WHERE id = $2`, [
+    desc,
+    campaignId,
+  ]);
+  return wrapSuccessResult(true);
+};
+
 export const sqlListCampaignsForAccount = async (
   tx: TX,
   accountId: string
@@ -706,7 +719,7 @@ export const sqlFetchCampaignInvitesByRecipientId = async (
   );
 };
 
-// Allow account to delete the campaign if they are the recipient, or a GM on the relevant campaign
+// Allow account to delete the invite if they are the recipient, or a GM on the relevant campaign
 export const sqlDeleteCampaignInvite = async (
   tx: TX,
   inviteId: string,

--- a/src/daos/sql.ts
+++ b/src/daos/sql.ts
@@ -7,6 +7,14 @@ import {
   wrapSuccessResult,
 } from "../utils/db";
 import {
+  AccountInfo,
+  Campaign,
+  CampaignEntity,
+  CampaignInvite,
+  CampaignInviteWithDetails,
+  CampaignMember,
+  CampaignRole,
+  CampaignWithRole,
   EntityAbility,
   EntityAttribute,
   EntityAttributes,
@@ -18,6 +26,8 @@ import {
   FullEntityFlux,
   FullEntityItem,
   FullEntityText,
+  PostCampaign,
+  PostCampaignInvite,
   Result,
   UncompleteEntity,
   UncompleteEntityAbility,
@@ -29,12 +39,17 @@ import {
 
 export type TX = PoolClient | Pool;
 
+export const ACCOUNTS_TABLE = "vennt.accounts";
 export const ENTITIES_TABLE = "vennt.entities";
 export const ABILITIES_TABLE = "vennt.abilities";
 export const ATTRIBUTE_CHANGELOG_TABLE = "vennt.attribute_changelog";
 export const ITEMS_TABLE = "vennt.items";
 export const ENTITY_TEXT_TABLE = "vennt.entity_text";
 export const FLUX_TABLE = "vennt.flux";
+export const CAMPAIGNS_TABLE = "vennt.campaigns";
+export const CAMPAIGN_INVITES_TABLE = "vennt.campaign_invites";
+export const CAMPAIGN_MEMBERS_TABLE = "vennt.campaign_members";
+export const CAMPAIGN_ENTITIES_TABLE = "vennt.campaign_entities";
 
 export const INSERT_ENTITY_COLUMNS = `owner, name, "type", attributes, other_fields, "public"`;
 export const INSERT_ABILITY_COLUMNS = `entity_id, name, effect, custom_fields, uses, comment, active`;
@@ -54,6 +69,8 @@ export const ITEM_COLUMNS = `${ITEMS_TABLE}.id, ${ITEMS_TABLE}.entity_id, ${ITEM
 export const ENTITY_TEXT_COLUMNS = `${ENTITY_TEXT_TABLE}.id, ${ENTITY_TEXT_TABLE}.entity_id, ${ENTITY_TEXT_TABLE}.key, ${ENTITY_TEXT_TABLE}.text, \
   ${ENTITY_TEXT_TABLE}.public`;
 export const FLUX_COLUMNS = `${FLUX_TABLE}.id, ${FLUX_TABLE}.entity_id, ${FLUX_TABLE}.type, ${FLUX_TABLE}.text, ${FLUX_TABLE}.metadata`;
+export const CAMPAIGN_COLUMNS = `${CAMPAIGNS_TABLE}.id, ${CAMPAIGNS_TABLE}.name, ${CAMPAIGNS_TABLE}.in_combat, ${CAMPAIGNS_TABLE}.init_index, \
+  ${CAMPAIGNS_TABLE}.init_round, ${CAMPAIGNS_TABLE}.desc`;
 
 // ENTITIES
 
@@ -588,4 +605,236 @@ export const sqlDeleteFlux = async (
     entityId,
   ]);
   return wrapSuccessResult(true);
+};
+
+// CAMPAIGNS
+
+export const sqlInsertCampaign = async (
+  tx: TX,
+  campaign: PostCampaign
+): Promise<Result<Campaign>> => {
+  return parseFirst(
+    await tx.query(
+      `INSERT INTO ${CAMPAIGNS_TABLE} (name, "desc")
+      VALUES ($1, $2)
+      RETURNING ${CAMPAIGN_COLUMNS}`,
+      [campaign.name, campaign.desc]
+    ),
+    500
+  );
+};
+
+export const sqlFetchCampaignById = async (
+  tx: TX,
+  campaignId: string
+): Promise<Result<Campaign>> => {
+  return parseFirst(
+    await tx.query(
+      `SELECT ${CAMPAIGN_COLUMNS} FROM ${CAMPAIGNS_TABLE} WHERE id = $1`,
+      [campaignId]
+    )
+  );
+};
+
+export const sqlListCampaignsForAccount = async (
+  tx: TX,
+  accountId: string
+): Promise<Result<CampaignWithRole[]>> => {
+  return parseList(
+    await tx.query(
+      `SELECT ${CAMPAIGN_COLUMNS}, cm.role
+      FROM ${CAMPAIGNS_TABLE}
+      JOIN ${CAMPAIGN_MEMBERS_TABLE} cm ON cm.campaign_id = ${CAMPAIGNS_TABLE}.id
+      WHERE cm.account_id = $1`,
+      [accountId]
+    )
+  );
+};
+
+export const sqlInsertCampaignInvite = async (
+  tx: TX,
+  invite: PostCampaignInvite,
+  from: AccountInfo
+): Promise<Result<CampaignInvite>> => {
+  return parseFirst(
+    await tx.query(
+      `INSERT INTO ${CAMPAIGN_INVITES_TABLE} (campaign_id, "from", "to", "role")
+      SELECT $1, $2, a.id, $3
+      FROM ${ACCOUNTS_TABLE} a
+      WHERE a.username = $4
+      RETURNING ${CAMPAIGN_INVITES_TABLE}.id, ${CAMPAIGN_INVITES_TABLE}.campaign_id, ${CAMPAIGN_INVITES_TABLE}.role, ${CAMPAIGN_INVITES_TABLE}.created,
+        $4 AS from, $5 AS to`,
+      [invite.campaign_id, from.id, invite.role, invite.to, from.username]
+    ),
+    500
+  );
+};
+
+export const sqlFetchCampaignInvitesByCampaignId = async (
+  tx: TX,
+  campaignId: string
+): Promise<Result<CampaignInvite[]>> => {
+  return parseList(
+    await tx.query(
+      `SELECT ci.id, ci.campaign_id, ci.role, ci.created, af.username AS from, at.username AS to
+      FROM ${CAMPAIGN_INVITES_TABLE} ci
+      JOIN ${ACCOUNTS_TABLE} af ON af.id = ci.from
+      JOIN ${ACCOUNTS_TABLE} at ON at.id = ci.to
+      WHERE ci.campaign_id = $1
+    `,
+      [campaignId]
+    )
+  );
+};
+
+export const sqlFetchCampaignInvitesByRecipientId = async (
+  tx: TX,
+  recipientId: string,
+  recipientUsername: string
+): Promise<Result<CampaignInviteWithDetails[]>> => {
+  return parseList(
+    await tx.query(
+      `SELECT ci.id, ci.campaign_id, ci.role, ci.created, a.username AS from, $2 AS to, c.name, c.desc
+      FROM ${CAMPAIGN_INVITES_TABLE} ci
+      JOIN ${ACCOUNTS_TABLE} a ON a.id = ci.from
+      JOIN ${CAMPAIGNS_TABLE} c ON c.id = ci.campaign_id
+      WHERE ci.to = $1
+    `,
+      [recipientId, recipientUsername]
+    )
+  );
+};
+
+// Allow account to delete the campaign if they are the recipient, or a GM on the relevant campaign
+export const sqlDeleteCampaignInvite = async (
+  tx: TX,
+  inviteId: string,
+  accountId: string
+): Promise<Result<boolean>> => {
+  await tx.query(
+    `DELETE FROM ${CAMPAIGN_INVITES_TABLE}
+    WHERE id = $1
+    AND ("to" = $2 OR EXISTS (
+      SELECT *
+      FROM ${CAMPAIGN_MEMBERS_TABLE} cm
+      WHERE cm.campaign_id = ${CAMPAIGN_INVITES_TABLE}.campaign_id
+      AND cm.account_id = $2
+      AND cm.role = 'GM'
+    ))`,
+    [inviteId, accountId]
+  );
+  return wrapSuccessResult(true);
+};
+
+export const sqlInsertCampaignMember = async (
+  tx: TX,
+  campaignId: string,
+  accountId: string,
+  role: CampaignRole
+): Promise<Result<CampaignMember>> => {
+  return parseFirst(
+    await tx.query(
+      `WITH inserted_campaign_member as (
+        INSERT INTO ${CAMPAIGN_MEMBERS_TABLE} (campaign_id, account_id, "role")
+        VALUES ($1, $2, $3)
+        RETURNING *
+      )
+      SELECT inserted_campaign_member.*, ${ACCOUNTS_TABLE}.username
+      FROM inserted_campaign_member
+      JOIN ${ACCOUNTS_TABLE} ON ${ACCOUNTS_TABLE}.id = inserted_campaign_member.account_id`,
+      [campaignId, accountId, role]
+    ),
+    500
+  );
+};
+
+export const sqlInsertCampaignMemberFromInvite = async (
+  tx: TX,
+  inviteId: string,
+  accountId: string
+): Promise<Result<CampaignMember>> => {
+  return parseFirst(
+    await tx.query(
+      `WITH inserted_campaign_member as (
+        INSERT INTO ${CAMPAIGN_MEMBERS_TABLE} (campaign_id, account_id, "role")
+        SELECT ci.campaign_id, ci.to, ci.role
+        FROM ${CAMPAIGN_INVITES_TABLE} ci WHERE ci.id = $1 AND ci.to = $2
+        RETURNING ${CAMPAIGN_MEMBERS_TABLE}.*
+      )
+      SELECT icm.*, a.username
+      FROM inserted_campaign_member icm
+      JOIN ${ACCOUNTS_TABLE} a ON a.id = icm.account_id`,
+      [inviteId, accountId]
+    ),
+    500
+  );
+};
+
+export const sqlFetchCampaignMembersByCampaignId = async (
+  tx: TX,
+  campaignId: string
+): Promise<Result<CampaignMember[]>> => {
+  return parseList(
+    await tx.query(
+      `SELECT cm.id, cm.campaign_id, cm.account_id, a.username, cm.role
+      FROM ${CAMPAIGN_MEMBERS_TABLE} cm
+      JOIN ${ACCOUNTS_TABLE} a ON a.id = cm.account_id
+      WHERE cm.campaign_id = $1
+    `,
+      [campaignId]
+    )
+  );
+};
+
+export const sqlFetchCampaignRole = async (
+  tx: TX,
+  campaignId: string,
+  accountId: string
+): Promise<Result<CampaignRole>> => {
+  return parseFirstVal(
+    await tx.query(
+      `SELECT "role" FROM ${CAMPAIGN_MEMBERS_TABLE} WHERE campaign_id = $1 AND account_id = $2`,
+      [campaignId, accountId]
+    )
+  );
+};
+
+export const sqlInsertCampaignEntity = async (
+  tx: TX,
+  campaignId: string,
+  entityId: string,
+  gmOnly: boolean
+): Promise<Result<CampaignEntity>> => {
+  return parseFirst(
+    await tx.query(
+      `WITH inserted_campaign_entity as (
+        INSERT INTO ${CAMPAIGN_ENTITIES_TABLE} (campaign_id, entity_id, gm_only)
+        VALUES ($1, $2, $3)
+        RETURNING *
+      )
+      SELECT ice.entity_id, ice.gm_only, e.owner, e.name, e.type, e.attributes, e.other_fields
+      FROM inserted_campaign_entity ice
+      JOIN ${ENTITIES_TABLE} e ON e.id = ice.entity_id`,
+      [campaignId, entityId, gmOnly]
+    ),
+    500
+  );
+};
+
+export const sqlFetchCampaignEntitiesByCampaignId = async (
+  tx: TX,
+  campaignId: string,
+  includeGmOnly?: boolean
+): Promise<Result<CampaignEntity[]>> => {
+  const gmOnlyCheck = includeGmOnly ? "" : "AND ce.gm_only = FALSE";
+  return parseList(
+    await tx.query(
+      `SELECT ce.entity_id, ce.gm_only, e.owner, e.name, e.type, e.attributes, e.other_fields
+      FROM ${CAMPAIGN_ENTITIES_TABLE} ce
+      JOIN ${ENTITIES_TABLE} e ON e.id = ce.entity_id
+      WHERE ce.campaign_id = $1 ${gmOnlyCheck}
+    `,
+      [campaignId]
+    )
+  );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import authRoute from "./routes/auth";
 import entityRoute from "./routes/entity";
 import itemRoute from "./routes/item";
 import adminRoute from "./routes/admin";
+import campaignRoute from "./routes/campaign";
+import campaignInvitesRoute from "./routes/campaignInvites";
 
 dotEnv.config();
 
@@ -32,6 +34,8 @@ app.use("/auth", authRoute);
 app.use("/entity", entityRoute);
 app.use("/item", itemRoute);
 app.use("/admin", adminRoute);
+app.use("/campaign", campaignRoute);
+app.use("/campaign_invite", campaignInvitesRoute);
 
 console.log(`${isProd ? "Production" : "Local"} server started`);
 

--- a/src/routes/campaign.ts
+++ b/src/routes/campaign.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import type { Request } from "express";
 import {
+  validateAdminWriteCampaignPermission,
   validateEditEntityPermission,
   validateReadCampaignPermission,
   validateWriteCampaignPermission,
@@ -11,9 +12,11 @@ import {
   dbInsertCampaign,
   dbInsertCampaignEntity,
   dbListCampaigns,
+  dbUpdateCampaignDesc,
 } from "../daos/campaignDao";
 import { validateAuthHeader } from "../utils/jwt";
 import {
+  campaignDescValidator,
   idValidator,
   postCampaignEntityValidator,
   postCampaignValidator,
@@ -37,6 +40,14 @@ const fetchCampaignDetails = async (req: Request) => {
   return await dbFetchFullCampaignDetails(campaignId, role);
 };
 
+const putCampaignDesc = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const campaignId = idValidator.parse(req.params.id);
+  await validateAdminWriteCampaignPermission(account, campaignId);
+  const body = campaignDescValidator.parse(req.body);
+  return await dbUpdateCampaignDesc(campaignId, body);
+};
+
 const addEntityToCampaign = async (req: Request) => {
   const account = validateAuthHeader(req);
   const body = postCampaignEntityValidator.parse(req.body);
@@ -50,5 +61,6 @@ const router = express.Router();
 router.post("", wrapHandler(addCampaign));
 router.get("", wrapHandler(listCampaign));
 router.get("/:id", wrapHandler(fetchCampaignDetails));
+router.put("/:id/desc", wrapHandler(putCampaignDesc));
 router.post("/:id/entity", wrapHandler(addEntityToCampaign));
 export default router;

--- a/src/routes/campaign.ts
+++ b/src/routes/campaign.ts
@@ -1,0 +1,54 @@
+import express from "express";
+import type { Request } from "express";
+import {
+  validateEditEntityPermission,
+  validateReadCampaignPermission,
+  validateWriteCampaignPermission,
+  wrapHandler,
+} from "../utils/express";
+import {
+  dbFetchFullCampaignDetails,
+  dbInsertCampaign,
+  dbInsertCampaignEntity,
+  dbListCampaigns,
+} from "../daos/campaignDao";
+import { validateAuthHeader } from "../utils/jwt";
+import {
+  idValidator,
+  postCampaignEntityValidator,
+  postCampaignValidator,
+} from "../utils/types";
+
+const addCampaign = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const body = postCampaignValidator.parse(req.body);
+  return await dbInsertCampaign(body, account.id);
+};
+
+const listCampaign = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  return await dbListCampaigns(account.id);
+};
+
+const fetchCampaignDetails = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const campaignId = idValidator.parse(req.params.id);
+  const role = await validateReadCampaignPermission(account, campaignId);
+  return await dbFetchFullCampaignDetails(campaignId, role);
+};
+
+const addEntityToCampaign = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const body = postCampaignEntityValidator.parse(req.body);
+  const campaignId = idValidator.parse(req.params.id);
+  const role = await validateWriteCampaignPermission(account, campaignId);
+  await validateEditEntityPermission(account, body.entity_id);
+  return await dbInsertCampaignEntity(campaignId, body, role);
+};
+
+const router = express.Router();
+router.post("", wrapHandler(addCampaign));
+router.get("", wrapHandler(listCampaign));
+router.get("/:id", wrapHandler(fetchCampaignDetails));
+router.post("/:id/entity", wrapHandler(addEntityToCampaign));
+export default router;

--- a/src/routes/campaignInvites.ts
+++ b/src/routes/campaignInvites.ts
@@ -1,0 +1,45 @@
+import express from "express";
+import type { Request } from "express";
+import {
+  validateAdminWriteCampaignPermission,
+  wrapHandler,
+} from "../utils/express";
+import {
+  dbAcceptCampaignInvite,
+  dbDeclineCampaignInvite,
+  dbInsertCampaignInvite,
+  dbListCampaignInvites,
+} from "../daos/campaignDao";
+import { validateAuthHeader } from "../utils/jwt";
+import { idValidator, postCampaignInviteValidator } from "../utils/types";
+
+const addCampaignInvite = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const body = postCampaignInviteValidator.parse(req.body);
+  await validateAdminWriteCampaignPermission(account, body.campaign_id);
+  return await dbInsertCampaignInvite(body, account);
+};
+
+const listCampaignInvites = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  return await dbListCampaignInvites(account);
+};
+
+const acceptCampaignInvite = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const inviteId = idValidator.parse(req.params.id);
+  return await dbAcceptCampaignInvite(inviteId, account.id);
+};
+
+const declineCampaignInvite = async (req: Request) => {
+  const account = validateAuthHeader(req);
+  const inviteId = idValidator.parse(req.params.id);
+  return await dbDeclineCampaignInvite(inviteId, account.id);
+};
+
+const router = express.Router();
+router.post("", wrapHandler(addCampaignInvite));
+router.get("", wrapHandler(listCampaignInvites));
+router.post("/:id", wrapHandler(acceptCampaignInvite));
+router.delete("/:id", wrapHandler(declineCampaignInvite));
+export default router;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -32,10 +32,9 @@ export const validateToken = (token: string): AccountInfo => {
 };
 
 export const validateAuthHeader = (req: Request): AccountInfo => {
-  const auth = req.header("Authorization");
-  const token = auth?.split(" ")[1]; // token comes after first space
-  if (token) {
-    return validateToken(token);
+  const account = validateOptionalAuthHeader(req);
+  if (account) {
+    return account;
   }
   throw new ResultError(UNAUTHORIZED_RESULT);
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -716,9 +716,11 @@ export const CAMPAIGN_ROLES = [
 ] as const;
 export const campaignRoleValidator = z.enum(CAMPAIGN_ROLES);
 
-export const postCampaignValidator = z.object({
-  name: nameValidator,
+export const campaignDescValidator = z.object({
   desc: z.string().max(COMMENT_MAX),
+});
+export const postCampaignValidator = campaignDescValidator.extend({
+  name: nameValidator,
 });
 
 export const campaignValidator = postCampaignValidator.extend({
@@ -895,6 +897,7 @@ export type PathDetails = z.infer<typeof pathDetailsValidator>;
 export type PathsAndAbilities = z.infer<typeof pathsAndAbilitiesValidator>;
 
 export type CampaignRole = z.infer<typeof campaignRoleValidator>;
+export type CampaignDesc = z.infer<typeof campaignDescValidator>;
 export type PostCampaign = z.infer<typeof postCampaignValidator>;
 export type Campaign = z.infer<typeof campaignValidator>;
 export type CampaignWithRole = z.infer<typeof campaignWithRoleValidator>;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -40,6 +40,7 @@ export const ATTRIBUTES_SET = new Set<EntityAttribute>(ATTRIBUTES);
 // GENERAL FIELDS
 
 export const idValidator = z.string().uuid();
+export const optionalIdValidator = idValidator.optional();
 export const nameValidator = z.string().min(1).max(NAME_MAX);
 export const equationValidator = z.union([
   z.number().int(),

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -703,6 +703,80 @@ export const fullCollectedEntityWithChangelogValidator =
     changelog: fullAttributeChangelogValidator.array(),
   });
 
+// CAMPAIGNS
+
+export const CAMPAIGN_ROLE_SPECTATOR = "SPECTATOR";
+export const CAMPAIGN_ROLE_PLAYER = "PLAYER";
+export const CAMPAIGN_ROLE_GM = "GM";
+export const CAMPAIGN_ROLES = [
+  CAMPAIGN_ROLE_SPECTATOR,
+  CAMPAIGN_ROLE_PLAYER,
+  CAMPAIGN_ROLE_GM,
+] as const;
+export const campaignRoleValidator = z.enum(CAMPAIGN_ROLES);
+
+export const postCampaignValidator = z.object({
+  name: nameValidator,
+  desc: z.string().max(COMMENT_MAX),
+});
+
+export const campaignValidator = postCampaignValidator.extend({
+  id: idValidator,
+  in_combat: z.boolean(),
+  init_index: z.number().int().nonnegative(),
+  init_round: z.number().int().nonnegative(),
+});
+
+export const campaignWithRoleValidator = campaignValidator.extend({
+  role: campaignRoleValidator,
+});
+
+export const postCampaignInviteValidator = z.object({
+  campaign_id: idValidator,
+  to: nameValidator,
+  role: campaignRoleValidator,
+});
+
+export const campaignInviteValidator = postCampaignInviteValidator.extend({
+  id: idValidator,
+  from: nameValidator,
+  created: z.string().datetime(),
+});
+
+export const campaignInviteWithDetailsValidator =
+  campaignInviteValidator.extend({
+    name: nameValidator,
+    desc: z.string().max(COMMENT_MAX),
+  });
+
+export const campaignMemberValidator = z.object({
+  id: idValidator,
+  campaign_id: idValidator,
+  account_id: idValidator,
+  username: nameValidator,
+  role: campaignRoleValidator,
+});
+
+export const postCampaignEntityValidator = z.object({
+  entity_id: idValidator,
+  gm_only: z.boolean(),
+});
+
+export const campaignEntityValidator = postCampaignEntityValidator.extend({
+  owner: idValidator,
+  name: nameValidator,
+  type: entityTypeValidator,
+  attributes: attributesValidator,
+  other_fields: otherAttributesValidator,
+});
+
+export const fullCampaignDetailsValidator = z.object({
+  campaign: campaignValidator,
+  invites: campaignInviteValidator.array().optional(),
+  members: campaignMemberValidator.array(),
+  entities: campaignEntityValidator.array(),
+});
+
 // other endpoints
 
 export const partialAttributesValidator = attributesValidator.partial();
@@ -818,6 +892,20 @@ export type JsonStorageKey = z.infer<typeof jsonStorageKeyValidator>;
 export type ShopItem = z.infer<typeof shopItemValidator>;
 export type PathDetails = z.infer<typeof pathDetailsValidator>;
 export type PathsAndAbilities = z.infer<typeof pathsAndAbilitiesValidator>;
+
+export type CampaignRole = z.infer<typeof campaignRoleValidator>;
+export type PostCampaign = z.infer<typeof postCampaignValidator>;
+export type Campaign = z.infer<typeof campaignValidator>;
+export type CampaignWithRole = z.infer<typeof campaignWithRoleValidator>;
+export type PostCampaignInvite = z.infer<typeof postCampaignInviteValidator>;
+export type CampaignInvite = z.infer<typeof campaignInviteValidator>;
+export type CampaignInviteWithDetails = z.infer<
+  typeof campaignInviteWithDetailsValidator
+>;
+export type PostCampaignEntity = z.infer<typeof postCampaignEntityValidator>;
+export type CampaignMember = z.infer<typeof campaignMemberValidator>;
+export type CampaignEntity = z.infer<typeof campaignEntityValidator>;
+export type FullCampaignDetails = z.infer<typeof fullCampaignDetailsValidator>;
 
 // SERVER TYPES
 

--- a/src/webscraper/abilitiesUses/paths/barbarian.ts
+++ b/src/webscraper/abilitiesUses/paths/barbarian.ts
@@ -4,4 +4,5 @@ export const BARBARIAN_USES: Record<string, UsesMap> = {
   "Tough Skin": { adjust: { time: "permanent", attr: { armor: 2 } } },
   "Iron Skin": { adjust: { time: "permanent", attr: { armor: 2 } } },
   "Steel Skin": { adjust: { time: "permanent", attr: { armor: 2 } } },
+  "Barbaric Reflexes": { heal: { attr: { reaction: 1 } } },
 };

--- a/src/webscraper/abilitiesUses/paths/tactician.ts
+++ b/src/webscraper/abilitiesUses/paths/tactician.ts
@@ -1,0 +1,5 @@
+import { UsesMap } from "../../../utils/types";
+
+export const TACTICIAN_USES: Record<string, UsesMap> = {
+  "Quick Thinking": { heal: { attr: { reaction: 3 } } },
+};

--- a/src/webscraper/abilitiesUses/paths/tinker.ts
+++ b/src/webscraper/abilitiesUses/paths/tinker.ts
@@ -1,6 +1,26 @@
 import { UsesMap } from "../../../utils/types";
 
 export const TINKER_USES: Record<string, UsesMap> = {
+  "Forge Onward!": {
+    adjust: {
+      time: "permanent",
+      attr: {
+        aggressive_dmg: 3,
+        balanced_dmg: 3,
+        bow_dmg: 3,
+        brawling_dmg: 3,
+        brutal_dmg: 3,
+        great_dmg: 3,
+        hookwhip_dmg: 3,
+        improvised_dmg: 3,
+        polearm_dmg: 3,
+        protector_dmg: 3,
+        thrown_dmg: 3,
+        unarmed_dmg: 3,
+        whip_dmg: 3,
+      },
+    },
+  },
   "Tinker's Training": {
     expose_combat_stats: ["bluespace"],
     adjust: {

--- a/src/webscraper/abilitiesUses/uses.ts
+++ b/src/webscraper/abilitiesUses/uses.ts
@@ -49,3 +49,16 @@ export const ABILITY_USES: Record<string, UsesMap> = {
   ...TINKER_USES,
   ...UNIVERSALIST_ARCANA_USES,
 };
+
+/*
+Query examining most used but unsupported abilities
+
+SELECT COUNT(*), a.name
+FROM vennt.abilities a
+JOIN vennt.entities e ON a.entity_id = e.id
+WHERE a.uses IS NULL
+AND e.type = 'CHARACTER'
+GROUP BY a.name
+ORDER BY COUNT(*) DESC
+LIMIT 50;
+*/


### PR DESCRIPTION
* Adds support for campaigns.
* If you are a GM, you can send invitations to more users
* Users can then accept invitations to join campaigns
* Players / GMs in campaigns can add entities to a campaign.
* Regardless of the public status of entities, GMs get write access to entities they don't own, Players / Spectators get read access to entities they don't own.